### PR TITLE
Typo fix in guide

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -110,7 +110,7 @@
                 Reading and writing memory is trivial with <b>probe-rs</b>.
             </p>
             <p>
-                <b>probe-rs</b> supports differnt word sizes and block transfers.
+                <b>probe-rs</b> supports different word sizes and block transfers.
             </p>
             <p>
                 Don't forget to unlock the flash before you write to it!


### PR DESCRIPTION
Thanks for all your work on probe-rs! I spotted a small typo in the guide page.