### PR TITLE
Fix RISC-V name

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -29,7 +29,7 @@
     ) }}
     {{ macros::card(
         title="Compatible",
-        content="ARM, RiscV, CMSIS-DAP, STLink, JLink probe-rs supports it all. And many more to come!",
+        content="ARM, RISC-V, CMSIS-DAP, STLink, JLink probe-rs supports it all. And many more to come!",
         img="/static/img/multilingual.svg",
         color="#BF3459"
     ) }}
@@ -88,7 +88,7 @@
         {{ macros::feature_entry(title="Flash programming", state="stable") }}
         {{ macros::feature_entry(title="Cargo integration", state="stable") }}
         {{ macros::feature_entry(title="CMSIS-Pack support", state="stable") }}
-        {{ macros::feature_entry(title="RiscV support", state="beta") }}
+        {{ macros::feature_entry(title="RISC-V support", state="beta") }}
         {{ macros::feature_entry(title="ARM support", state="stable") }}
         {{ macros::feature_entry(title="CMSIS-DAP (DAP-Link) support", state="stable") }}
         {{ macros::feature_entry(title="ST-Link support", state="stable") }}


### PR DESCRIPTION
See also: https://riscv.org/risc-v-branding-guidelines-and-materials/