### PR TITLE
Adding Crosscompiling section, Example Dockerfile

### DIFF
--- a/content/cross-dockerfile.txt
+++ b/content/cross-dockerfile.txt
@@ -1,0 +1,6 @@
+FROM rustembedded/cross:armv7-unknown-linux-gnueabihf-0.2.1
+ENV PKG_CONFIG_ALLOW_CROSS=1
+ENV PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig
+RUN dpkg --add-architecture armhf && \
+    apt-get update && \
+    apt-get install -y libusb-1.0-0-dev:armhf

--- a/content/guide/4_development/crosscompiling.md
+++ b/content/guide/4_development/crosscompiling.md
@@ -22,7 +22,7 @@ The downside of this approach is that **you will have to rely on the Cross Proje
 Building `cargo-flash` for the Raspberry Pi 400, on an `x86_64` Linux System will happen as follows :
 
 ```sh
-# Cloning cargo-flash on the system we will build the binary
+# Cloning cargo-flash on the system we will build the binary on.
 git clone https://github.com/probe-rs/cargo-flash
 
 # Installing cross

--- a/content/guide/4_development/crosscompiling.md
+++ b/content/guide/4_development/crosscompiling.md
@@ -32,7 +32,7 @@ cargo install cross
 # And Create a `crossimage` folder
 cd cargo-flash && mkdir crossimage
 
-# Create a Dockerfile resempling the target system,
+# Create a Dockerfile resembling the target system,
 # and put it inside the crossimage Folder
 ```
 

--- a/content/guide/4_development/crosscompiling.md
+++ b/content/guide/4_development/crosscompiling.md
@@ -1,0 +1,69 @@
++++
+title = "Crosscompiling"
++++
+Even though **probe-rs** can run on most systems, there can be cases where using `cargo install` is not possible due to system permissions or resource limitations.
+
+In such cases you can Crosscompile **probe-rs** for use in **cargo-flash** or **cargo-embed** on a different architecture, and move the resulting static binary to the target system.
+
+We will use a [**Raspberry pi 400**](https://www.raspberrypi.org/products/raspberry-pi-400/) as the target system as an example, where `cargo install cargo-flash` on a default **Raspberry PI OS** installation is not possible to pass the `rustc` final Linking step for `probe-rs` due to system memory limitations.
+
+After defining the target system architecture, in this example being `armv7-unknown-linux-gnueabihf`, here are two different ways to Crosscompile, each with their pros and cons.
+
+## Using Cross
+
+[Cross](https://github.com/rust-embedded/cross) self defines as:
+
+> “Zero setup” cross compilation and “cross testing” of Rust crates
+
+It's main advantage is to **not be suseptible** on the usual cross compilation issues that arise **from using Host machine's shared object libraries**, by using a Docker image to build the static binary.
+
+The downside of this approach is that **you will have to rely on the Cross Project** and **supply the build environment Dockerfile**, making sure that it resembles as much as possible the system you are building for with **a cross C toolchain installed**.
+
+Building `cargo-flash` for the Raspberry Pi 400, on an `x86_64` Linux System will happen as follows :
+
+```sh
+# Cloning cargo-flash on the system we will build the binary
+git clone https://github.com/probe-rs/cargo-flash
+
+# Installing cross
+cargo install cross
+
+# CD into the cargo-flash repository
+# And Create a `crossimage` folder
+cd cargo-flash && mkdir crossimage
+
+# Create a Dockerfile resempling the target system,
+# and put it inside the crossimage Folder
+```
+
+We can take a `armv7-unknown-linux-gnueabihf` base system from the `rustembedded/cross` Docker hub container registry.
+
+Then, we need to follow the instructions to prepare it for building steps the image from the `probe-rs`, `cargo-flash` [prerequisites](https://github.com/probe-rs/cargo-flash#prerequisites).
+
+You can download the Dockerfile for this example from [here](/content/cross-dockerfile.txt)
+
+```sh
+# Create and edit a Cross.toml file on the root of the cloned repo
+vim Cross.toml
+```
+
+Add the following inside the **Cross.toml**. Which will define to `cross` which container should be used for the target Architecture :
+
+<pre>[target.armv7-unknown-linux-gnueabihf]
+image = "crossimage"</pre>
+
+```sh
+# Build and tag the container image, specifying the name as defined on Cross.toml
+docker build -t crossimage crossimage/
+
+# Run cross to compile, cross arguments are the same as the `cargo` ones
+cross build --release --target=armv7-unknown-linux-gnueabihf
+
+# Done
+```
+
+You will now have a statically built `cargo-flash` binary inside the `target/<architecture>/release` folder on the root directory of the cloned repo, which you can now move to the **Raspberry Pi 400** `Cargo bin Path` folder ( usually `~/.cargo/bin` ).
+
+## Using LLVM
+
+As using `LLVM` for cosscompiling can go out of the scope of just generating a `cargo-flash` binary, Please follow the instructions on how to Crosscompile from the **LLVM** [guide](https://www.llvm.org/docs/HowToCrossCompileLLVM.html).

--- a/content/guide/4_development/crosscompiling.md
+++ b/content/guide/4_development/crosscompiling.md
@@ -19,7 +19,7 @@ Its main advantage is to **not be susceptible** on the usual cross compilation i
 
 The downside of this approach is that **you will have to rely on the Cross Project** and **supply the build environment Dockerfile**, making sure that it resembles the system you are building for with **a cross C toolchain installed** as much as possible.
 
-Building `cargo-flash` for the Raspberry Pi 400, on an `x86_64` Linux System will happen as follows :
+Building `cargo-flash` for the Raspberry Pi 400, on an `x86_64` Linux System happens as follows:
 
 ```sh
 # Cloning cargo-flash on the system we will build the binary on.
@@ -29,31 +29,33 @@ git clone https://github.com/probe-rs/cargo-flash
 cargo install cross
 
 # `cd` into the cargo-flash repository
-# And Create a `crossimage` folder
+# And create a `crossimage` folder
 cd cargo-flash && mkdir crossimage
 
 # Create a Dockerfile resembling the target system,
-# and put it inside the crossimage Folder
+# and put it inside the `crossimage` folder.
 ```
 
-We can take a `armv7-unknown-linux-gnueabihf` base system from the `rustembedded/cross` Docker hub container registry.
+We can take an `armv7-unknown-linux-gnueabihf` base system from the `rust-embedded/cross` Docker Hub container registry.
 
-Then, we need to follow the instructions to prepare it for building steps the image from the `probe-rs`, `cargo-flash` [prerequisites](https://github.com/probe-rs/cargo-flash#prerequisites).
+After that, follow the instructions from the `probe-rs`, `cargo-flash` [prerequisites](https://github.com/probe-rs/cargo-flash#prerequisites) to prepare the image for the building steps.
 
-You can download the Dockerfile for this example from [here](/content/cross-dockerfile.txt)
+You can download the Dockerfile for this example from [here](/content/cross-dockerfile.txt).
 
 ```sh
-# Create and edit a Cross.toml file on the root of the cloned repo
+# Create and edit a Cross.toml file in the root of the cloned repo.
 vim Cross.toml
 ```
 
 Add the following to the `Cross.toml`. Which will define to `cross` which container should be used for the target architecture:
 
-<pre>[target.armv7-unknown-linux-gnueabihf]
-image = "crossimage"</pre>
+    ```toml
+    [target.armv7-unknown-linux-gnueabihf]
+    image = "crossimage"
+    ```
 
 ```sh
-# Build and tag the container image, specifying the name as defined on Cross.toml
+# Build and tag the container image, specifying the name as defined in the `Cross.toml`.
 docker build -t crossimage crossimage/
 
 # Run cross to compile, cross arguments are the same as the `cargo` ones
@@ -62,8 +64,8 @@ cross build --release --target=armv7-unknown-linux-gnueabihf
 # Done
 ```
 
-You will now have a statically built `cargo-flash` binary inside the `target/<architecture>/release` folder on the root directory of the cloned repo, which you can now move to the **Raspberry Pi 400** `Cargo bin Path` folder ( usually `~/.cargo/bin` ).
+You now have a statically built `cargo-flash` binary inside the `target/<architecture>/release` folder on the root directory of the cloned repo, which you can now move to the **Raspberry Pi 400** `cargo bin path` folder (usually `~/.cargo/bin`).
 
 ## Using LLVM
 
-As using `LLVM` for cosscompiling can go out of the scope of just generating a `cargo-flash` binary, Please follow the instructions on how to Crosscompile from the **LLVM** [guide](https://www.llvm.org/docs/HowToCrossCompileLLVM.html).
+As using `LLVM` for cosscompiling can go out of the scope of just generating a `cargo-flash` binary, please follow the instructions on how to crosscompile in the **LLVM** [guide](https://www.llvm.org/docs/HowToCrossCompileLLVM.html).

--- a/content/guide/4_development/crosscompiling.md
+++ b/content/guide/4_development/crosscompiling.md
@@ -47,7 +47,7 @@ You can download the Dockerfile for this example from [here](/content/cross-dock
 vim Cross.toml
 ```
 
-Add the following inside the **Cross.toml**. Which will define to `cross` which container should be used for the target Architecture :
+Add the following to the `Cross.toml`. Which will define to `cross` which container should be used for the target architecture:
 
 <pre>[target.armv7-unknown-linux-gnueabihf]
 image = "crossimage"</pre>

--- a/content/guide/4_development/crosscompiling.md
+++ b/content/guide/4_development/crosscompiling.md
@@ -28,7 +28,7 @@ git clone https://github.com/probe-rs/cargo-flash
 # Installing cross
 cargo install cross
 
-# CD into the cargo-flash repository
+# `cd` into the cargo-flash repository
 # And Create a `crossimage` folder
 cd cargo-flash && mkdir crossimage
 

--- a/content/guide/4_development/crosscompiling.md
+++ b/content/guide/4_development/crosscompiling.md
@@ -17,7 +17,7 @@ After defining the target system architecture, in this example being `armv7-unkn
 
 Its main advantage is to **not be susceptible** on the usual cross compilation issues that arise **from using the host machine's shared object libraries**, by using a Docker image to build the static binary.
 
-The downside of this approach is that **you will have to rely on the Cross Project** and **supply the build environment Dockerfile**, making sure that it resembles as much as possible the system you are building for with **a cross C toolchain installed**.
+The downside of this approach is that **you will have to rely on the Cross Project** and **supply the build environment Dockerfile**, making sure that it resembles the system you are building for with **a cross C toolchain installed** as much as possible.
 
 Building `cargo-flash` for the Raspberry Pi 400, on an `x86_64` Linux System will happen as follows :
 

--- a/content/guide/4_development/crosscompiling.md
+++ b/content/guide/4_development/crosscompiling.md
@@ -15,7 +15,7 @@ After defining the target system architecture, in this example being `armv7-unkn
 
 > “Zero setup” cross compilation and “cross testing” of Rust crates
 
-It's main advantage is to **not be suseptible** on the usual cross compilation issues that arise **from using Host machine's shared object libraries**, by using a Docker image to build the static binary.
+Its main advantage is to **not be susceptible** on the usual cross compilation issues that arise **from using the host machine's shared object libraries**, by using a Docker image to build the static binary.
 
 The downside of this approach is that **you will have to rely on the Cross Project** and **supply the build environment Dockerfile**, making sure that it resembles as much as possible the system you are building for with **a cross C toolchain installed**.
 


### PR DESCRIPTION
In this PR : 

- Creating a new Page under **4. Development** about crosscompiling `cargo-flash` by using `cross` or `LLVM`
- Adding an Example Dockerfile for `cross` usage

I had an issue with building `cargo-flash` on the **Rasp pi 400**, as it went OOM on the `rustc` linking step.

The Probe-rs Matrix channel was very helpfull and pointed me into the direction of `cross` and `LLVM` targets as options to succesfully overcome this limitation, including an example `Dockerfile`. Now i want to share the knowledge.

While writing the documentation for `LLVM` though, it became apparent that it would require a lof of information about how to use and debug it's toolchain, which made the page go out of context ( in my opinion ). So a link to how someone can use `LLVM` to Crosscompile replaced that section.

In the way i see it, this PR satisfies the initial goal, as any other user that experiences my issue on compiling in limited environments will now have somewhere to start, and a solution using `cross`. 

in short, If you already know how to use LLVM for a different target, you will do it. if not, learning how might be out of the scope of this page. Open for discussion on this point.
