### PR TITLE
Expand explanation of cargo embed configuartion a bit (and other little things)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,10 @@ title = 'probe-rs'
 highlight_code = true
 highlight_theme = "ayu-light"
 
+# Whether external links are to be opened in a new tab
+# If this is true, a `rel="noopener"` will always automatically be added for security reasons
+external_links_target_blank = true
+
 [extra]
 # Put all your custom variables here
 
@@ -48,4 +52,4 @@ post = 'v0.1.0'
 weight = 20
 
 [extra.footer]
-info = '© 2019 - 2021 the probe-rs developers'
+info = '© 2019 - 2022 the probe-rs developers'

--- a/content/docs/library/quickstart.md
+++ b/content/docs/library/quickstart.md
@@ -34,18 +34,16 @@ let core = session.core(0)?;
 core.halt()?;
 ```
 
-<b>probe-rs</b> can be used to automate your workflow.
+**probe-rs** can be used to automate your workflow.
 
 Want to do
-<ul>
-    <li>hardware-in-the-loop testing?</li>
-    <li>automatic WCET analysis?</li>
-    <li>automatic firmware downloads in your project?</li>
-</ul>
+* hardware-in-the-loop testing?
+* automatic WCET analysis?
+* automatic firmware downloads in your project?
 
-<b>probe-rs</b> was designed with such usecases in mind.<br>
+**probe-rs** was designed with such usecases in mind.
 
-Read more about <a href="/guide/basics#structure">the structure</a>.
+Read more about [the structure](/guide/basics#structure).
 
 ## Reading and writing memory
 
@@ -74,14 +72,14 @@ let buff = [0u8;50];
 core.write_8(0x2000_0000, &buff)?;
 ```
 
-Reading and writing memory is trivial with <b>probe-rs</b>.
+Reading and writing memory is trivial with **probe-rs**.
 
-<b>probe-rs</b> supports different word sizes and block transfers.
+**probe-rs** supports different word sizes and block transfers.
 
 Don't forget to unlock the flash before you write to it!
 
-Read more about <a href="/guide/basics#core">memory operations</a>.
-    
+Read more about [memory operations](/guide/basics#core).
+
 ## Downloading to flash
 
 ```rs
@@ -113,9 +111,9 @@ download_file(
 
 Downloading firmware to your target is as easy.
 
-Of course the flash facility can also report progress.<br>
+Of course the flash facility can also report progress.
 
-Any target that has a CMSIS-Pack can be converted into a <b>probe-rs</b> flash download target with our
-<a href="https://github.com/probe-rs/target-gen" target="_blank">utility</a>
+Any target that has a CMSIS-Pack can be converted into a **probe-rs** flash download target with our
+[utility](https://github.com/probe-rs/target-gen)
 
-Read more about <a href="/guide/downloading">downloading flash</a>.
+Read more about [downloading flash](/guide/downloading).

--- a/content/docs/tools/cargo-embed.md
+++ b/content/docs/tools/cargo-embed.md
@@ -2,7 +2,7 @@
 title = "cargo-embed"
 description = "The cargo-embed utility explained."
 date = 2021-05-01T08:00:00+00:00
-updated = 2021-05-01T08:00:00+00:00
+updated = 2022-06-01T08:00:00+00:00
 draft = false
 weight = 20
 sort_by = "weight"
@@ -13,51 +13,46 @@ toc = true
 top = false
 +++
 
-## Basics
+**cargo-embed** is the big brother of cargo-flash.
 
-<b>cargo-embed</b> is the big brother of cargo-flash.<br>
-It can also flash a target just like cargo-flash, but it can also open an RTT terminal as well as a GDB server.<br>
-<br>
+It can also flash a target just like cargo-flash, but it can also open an RTT terminal as well as a GDB server.
+
 And there is much more to come in the future!
 
-<h3 class="guide">Installation</h3>
+## Installation
 
-<a href="https://crates.io/crates/cargo-embed"
-    target="_blank">cargo-embed</a> can be found on crates.io.
+[cargo-embed](https://crates.io/crates/cargo-embed) can be found on crates.io.
 We recommend installing it via
-<pre>cargo install cargo-embed</pre>
 
-<h3 class="guide">Configuration</h3>
+    cargo install cargo-embed
+
+## Configuration
 
 cargo-embed can be configured via a `Embed.toml` in the project root.
 
 The data from this file is structured in two levels; the outer layer is a configuration profile name, inside each configuration there are then a series of sections with different options. When invoking cargo-embed, a different configuration name can be passed as an argument, which will load the settings under that profile instead of `default`.
 
-The available options can be found in the <a href="https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml" target="_blank">default.toml</a>. This example uses toml syntax to set each option under the `default` top-level profile key.
+The available options can be found in the [default.toml](https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml). This example uses toml syntax to set each option under the `default` top-level profile key.
 
-<h2 class="guide" id="RTT">RTT</h2>
+## RTT
 
-RTT stands for real time transfers and is a mechanism to transfer data between the debug host and the debuggee.<br>
-<br>
+RTT stands for real time transfers and is a mechanism to transfer data between the debug host and the debuggee.
+
 In it's essence it provides a configurable amount of ringbuffers, which are read/written by the target and the debug
 host.
-The protocol initially was published by <a
-    href="https://www.segger.com/products/debug-probes/j-link/technology/about-real-time-transfer/"
-    target="_blank">Segger</a> but there is really no magic to it other than ringbuffers being used.
-This mechanism allows us to transfer data from the target to the host and vice versa really fast.<br>
-<br>
+The protocol initially was published by [Segger](https://www.segger.com/products/debug-probes/j-link/technology/about-real-time-transfer/) but there is really no magic to it other than ringbuffers being used.
+This mechanism allows us to transfer data from the target to the host and vice versa really fast.
+
 RTT features:
-<ul>
-    <li>Fast duplex data transfers</li>
-    <li>A configurable amount of channels(buffers)</li>
-    <li>Channels can be blocking and non blocking - your choice</li>
-</ul>
+* Fast duplex data transfers
+* A configurable amount of channels(buffers)
+* Channels can be blocking and non blocking - your choice
 
 This guide should get you going in no time to speed up your development with probe-rs.
 
-<h3 class="guide" id="target-simple">The target side</h3>
+### Target
 
-For the target side, we offer <a href="https://crates.io/crates/rtt-target" target="_blank">rtt-target</a>, a small lib
+For the target side, we offer [rtt-target](https://crates.io/crates/rtt-target), a small lib
 to set up the RTT structures in the target memory and read/write data from/to them.
 
 A minimal example of a host firmware would be
@@ -79,19 +74,19 @@ fn main() -> ! {
 }
 ```
 
-<h3 class="guide" id="host-simple">The host side</h3>
+### Host
 
 On the host, just run
 
-<pre>cargo-embed</pre>
+    cargo-embed
 
 with RTT enabled in the Embed.toml file.
 
-Now you should be able to see all the 'Hello World!'s in a default Channel called Terminal!
+Now you should be able to see all the 'Hello World!'s in a default channel called "Terminal"!
 
-<center><img src="/img/cargo-embed-simple.png" style="margin-top: 1em; margin-bottom: 1em;" /></center>
+![Hello World output via RTT](/img/cargo-embed-simple.png)
 
-<h3 class="guide" id="target-simple">Don't panic!</h3>
+### Don't panic!
 
 Of course it is easy to log all panics via RTT! Here is a most simple example of a panic handler:
 
@@ -127,15 +122,14 @@ fn panic(info: &PanicInfo) -> ! {
 
 And in the open rttui view you should see the panic.
 
-<center><img src="/img/cargo-embed-panic.png" style="margin-top: 1em; margin-bottom: 1em;" /></center>
+![Example panic logged to your channel](/img/cargo-embed-panic.png)
 
 We intentionally ship no default panic handler, so that you may choose the channel of your choice to log the panic
-to!<br>
-<br>
+to.
 
 So how do I get more channels, you might ask. Read on!
 
-<h3 class="guide" id="target-simple">All the channels!</h3>
+### All the channels!
 
 You can define multiple channels via a provided macro as seen in this snippet
 
@@ -217,16 +211,16 @@ fn main() -> ! {
 
 In this example we define three up channels and one down channel.
 The third up channel continuously logs, the second prints just a single info message and what the first one does, you'll
-figure it when you examine channel two ;)<br>
-<br>
+figure it when you examine channel two ;)
+
 On the host side it looks like
 
-<center><img src="/img/cargo-embed.png" style="margin-top: 1em; margin-bottom: 1em;" /></center>
+![Output of chree channels](/img/cargo-embed.png)
 
 As you can observe, we see all three up channels. You can switch to and from them with the F-keys.
 The down channel will automatically be associated with the corresponding up channel and an input field will
 automatically be displayed for channels with a corresponding down channel. This is done via the channel number, which
 must be the same for the up and down channels. This is the default rttui behavior and can be configured. RTT itself can handle any up/down
-numbers combination.<br>
-<br>
+numbers combination.
+
 Now you should be able to debug conveniently. Happy coding!

--- a/content/docs/tools/cargo-embed.md
+++ b/content/docs/tools/cargo-embed.md
@@ -28,15 +28,54 @@ We recommend installing it via
 
 ## Configuration
 
-cargo-embed can be configured via a `Embed.toml` in the project root.
+cargo-embed can be configured via a `Embed.toml` (or `.embed.toml`) in the project root.
 
-The data from this file is structured in two levels; the outer layer is a configuration profile name, inside each configuration there are then a series of sections with different options. When invoking cargo-embed, a different configuration name can be passed as an argument, which will load the settings under that profile instead of `default`.
+Here's a simple example:
 
-The available options can be found in the [default.toml](https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml). This example uses toml syntax to set each option under the `default` top-level profile key.
+```toml
+[default.general]
+chip = "STM32F401CCUx"
+
+[default.rtt]
+enabled = true
+```
+
+All available options can be found in the
+[default.toml](https://github.com/probe-rs/cargo-embed/blob/master/src/config/default.toml). This
+example uses toml syntax to set each option under the `default` top-level profile key.
+
+The `Embed.toml` should be part of the project, for local-only configuration overrides, you can
+create an `Embed.local.toml` (or `.embed.local.toml`) file and add that to your .gitignore.
+The local files take precedence.
+
+### Profiles
+
+The data in the `Embed.toml` is structured in two levels: The outer layer is a configuration profile
+name, inside each profile there are then a series of sections with different options.
+The default profile is called "default" ;)
+When invoking cargo-embed, a different profile name can be passed as an argument with `--config <profile>`, which will load the settings
+under that profile instead of `default`.
+
+For example, in your `Embed.toml`:
+
+```toml
+[default.general]
+chip = "STM32F401CCUx"
+
+# No need to set this again, other profiles inherit from the "default" profile
+#[with_rtt.general]
+#chip = "STM32F401CCUx"
+
+[with_rtt.rtt]
+enabled = true
+```
+
+Now you can run `cargo embed --config with_rtt` to have RTT enabled, while `cargo embed` will use
+the default config "default" without RTT.
 
 ## RTT
 
-RTT stands for real time transfers and is a mechanism to transfer data between the debug host and the debuggee.
+RTT stands for **real time transfers** and is a mechanism to transfer data between the debug host and the debuggee.
 
 In it's essence it provides a configurable amount of ringbuffers, which are read/written by the target and the debug
 host.
@@ -78,9 +117,9 @@ fn main() -> ! {
 
 On the host, just run
 
-    cargo-embed
+    cargo embed
 
-with RTT enabled in the Embed.toml file.
+with RTT enabled in the `Embed.toml` file.
 
 Now you should be able to see all the 'Hello World!'s in a default channel called "Terminal"!
 

--- a/content/docs/tools/cargo-flash.md
+++ b/content/docs/tools/cargo-flash.md
@@ -13,14 +13,17 @@ toc = true
 top = false
 +++
 
-## Basics
-
 **cargo-flash** is a cargo extension and drop in replacement for `cargo run`.
+
+## Installation
 
 We recommend you install it with cargo after installing the [prerequisites](https://github.com/probe-rs/cargo-flash#prerequisites).
 ```sh
 cargo install cargo-flash
 ```
+
+## Usage
+
 You can use **cargo-flash** just like 'cargo run', but instead of running on the host,
 **cargo-flash** will download your binary to the target and run.
 
@@ -41,7 +44,7 @@ cargo flash --list-chips
 cargo flash --example <your_example>
 ```
 
-Any config flags that are accepted by 'cargo run' are accepted by <b>cargo-flash</b> too.
+Any config flags that are accepted by 'cargo run' are accepted by **cargo-flash** too.
 If not, hit us with an [issue](https://github.com/probe-rs/cargo-flash/issues/new/choose).
 
 Happy coding!

--- a/content/docs/tools/vscode.md
+++ b/content/docs/tools/vscode.md
@@ -13,8 +13,6 @@ toc = true
 top = false
 +++
 
-## Basics
-
 The **probe-rs-debugger VS Code extension** uses the Microsoft Debug Adapter Protocol to implement an interactive debugging experience between VS Code and a probe-rs target.
 
 The extension is currently in pre-production/Alpha stage, with limited functionality. For details of current status and functionality please read this [section](#current-working-functionality-and-known-limitations).
@@ -68,7 +66,7 @@ A minimum configuration would look something like this (required customizations 
 }
 ```
 
-The following fully configured examples can be used (with customizations to reflect your own project and chip) to help you get started.<br>
+The following fully configured examples can be used (with customizations to reflect your own project and chip) to help you get started.
 
 #### Using the `launch` request type
 
@@ -174,7 +172,7 @@ Then use the following `launch.json` to connect to it:
 
 `probe-rs-debugger` and the VS Code extension supports using RTT in your target application.
 
-For more information on how to configure your target application to use RTT, please refer to the instructions under the [cargo-embed](../cargo-embed#RTT)
+For more information on how to configure your target application to use RTT, please refer to the instructions under the [cargo-embed](../cargo-embed#rtt)
 section of this guide.
 
 In order to capture the RTT output in the VSCode extension, you will need to supply additional entries to your applications `launch.json` entry. You can use the following example and modify the channel information to match the `rtt-target` channel configurations in your application.
@@ -210,7 +208,7 @@ In order to capture the RTT output in the VSCode extension, you will need to sup
 }
 ```
 
-In addition to supporting RTT channels with <a href="https://crates.io/crates/rtt-target" target="_blank">rtt-target</a>, we also support using the <a href="https://defmt.ferrous-systems.com" target="_blank">defmt</a> (a highly efficient logging framework that targets resource-constrained devices, and supports complex formatting and RUST_LOG-like logging)<br>
+In addition to supporting RTT channels with [rtt-target](https://crates.io/crates/rtt-target), we also support using the [defmt](https://defmt.ferrous-systems.com) (a highly efficient logging framework that targets resource-constrained devices, and supports complex formatting and RUST_LOG-like logging.)
 
 When using `defmt`, we can configure the client side based on what is captured in your application, and the `launch.json` only requires a single additional entry.
 

--- a/templates/macros/docs-toc.html
+++ b/templates/macros/docs-toc.html
@@ -6,7 +6,7 @@
   			<nav id="TableOfContents">
   					<ul>
   							{% for h1 in page.toc %}
-  							<li><a href="{{ h1.permalink | safe}}">{{ h1.title }}</a></li>
+  							<li><a href="{{ h1.permalink | safe}}">{{ h1.title }}</a>
   							{% if h1.children %}
   									<ul>
   											{% for h2 in h1.children %}
@@ -15,6 +15,7 @@
   									</ul>
   							{% endif %}
   							{% endfor %}
+                            </li>
   					</ul>
   			</nav>
   	</div>


### PR DESCRIPTION
Apart from explaining the configuration a bit better, this also converts some HTML to markdown for readability and makes the ToC on the right side properly two-leveled:

| Before: | After |
|---------|-------|
| ![image](https://user-images.githubusercontent.com/933300/171448087-2e87b0c7-b1b0-4f5e-9bbe-92729678745d.png) | ![image](https://user-images.githubusercontent.com/933300/171448121-0dd0e45f-00b4-47ed-b964-d1b09feb71de.png) |

