### PR TITLE
Add missing dependencies libftdi1-dev libudev-dev

### DIFF
--- a/static/files/cross-dockerfile.txt
+++ b/static/files/cross-dockerfile.txt
@@ -3,4 +3,4 @@ ENV PKG_CONFIG_ALLOW_CROSS=1
 ENV PKG_CONFIG_LIBDIR=/usr/lib/arm-linux-gnueabihf/pkgconfig
 RUN dpkg --add-architecture armhf && \
     apt-get update && \
-    apt-get install -y libusb-1.0-0-dev:armhf
+    apt-get install -y libusb-1.0-0-dev:armhf libftdi1-dev:armhf libudev-dev:armhf


### PR DESCRIPTION
Encountered the following error while building Cross using instructions on Cross-building:
`thread 'main' panicked at 'Unable to find libudev: "pkg-config" "--libs" "--cflags" "libudev" did not exit successfully: exit status: 1
`
Found resolution for issue for Ubuntu Linux install to include dependencies, applied same to docker image: [Cargo-embed #338](https://github.com/probe-rs/cargo-embed/pull/338)