### PR TITLE
Add authors taxonomy to config file

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,6 +9,10 @@ build_search_index = true
 
 title = 'probe-rs'
 
+taxonomies = [
+    {name = "authors"}
+]
+
 [markdown]
 # Whether to do syntax highlighting
 # Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola


### PR DESCRIPTION
This seems to be required by the newest Zola version.