### PR TITLE
udev: add rules for Espressif USB debuggers

### DIFF
--- a/static/files/69-probe-rs.rules
+++ b/static/files/69-probe-rs.rules
@@ -52,6 +52,10 @@ ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1018", MODE="660", GROUP="plugdev", 
 ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1051", MODE="660", GROUP="plugdev", TAG+="uaccess"
 ATTRS{idVendor}=="1366", ATTRS{idProduct}=="1061", MODE="660", GROUP="plugdev", TAG+="uaccess"
 
+# Espressif USB JTAG/serial debug unit
+ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1001", MODE="660", GROUP="plugdev", TAG+="uaccess"
+# Espressif USB Bridge
+ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1002", MODE="660", GROUP="plugdev", TAG+="uaccess"
 
 # CMSIS-DAP compatible adapters
 ATTRS{product}=="*CMSIS-DAP*", MODE="660", GROUP="plugdev", TAG+="uaccess"


### PR DESCRIPTION
This adds two udev rules allowing `plugdev` group access to Espressif USB debuggers. Mostly useful when targeting RISC-V based esp32 chips, like `esp32c3`.

Ref: https://esp-rs.github.io/book/tooling/debugging/probe-rs.html#permissions---linux