### PR TITLE
add libudev-dev to getting started guide

### DIFF
--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ Additionally, probe-rs depends on [libusb](https://libusb.info/) and optionally 
 On Debian and derived distros (e.g. Ubuntu), the following packages need to be installed:
 
 ```bash
-sudo apt install -y pkg-config libusb-1.0-0-dev libftdi1-dev
+sudo apt install -y pkg-config libusb-1.0-0-dev libftdi1-dev libudev-dev
 ```
 
 If the libusb v0.1 dev package (`libusb-dev`) is installed when dependant crates are built, you may get link failures at the end of the build.


### PR DESCRIPTION
I found that I needed libudev-dev on a relatively fresh install of Ubuntu 22.04 aswell.