### PR TITLE
Update outdated links, add missing deps

### DIFF
--- a/content/blog/release-0.11.0.md
+++ b/content/blog/release-0.11.0.md
@@ -89,7 +89,10 @@ And another cool thing sequences will enable is automatic target detection! No m
 This is entangled somewhat with debug sequences and will most likely hit together.
 Unlocking and flashing of a nRF5340 (two M33 cores) already works, but we are missing a few changes to the core library which will have to be made to finalize this addition.
 
-Not part of this PR, but closely related and under development as well is SWD v2 Multidrop support. This will enable us to flash chips like the RaspberryPI Pico. While a useable [fork](https://github.com/rp-rs/probe-rs) already exists, some work is still left to integrate this properly into the probe-rs core.
+Not part of this PR, but closely related and under development as well is SWD v2 Multidrop support. This will enable us to flash chips like the RaspberryPI Pico. ~~While a useable fork already exists, some work is still left to integrate this properly into the probe-rs core.~~
+
+Update: The changes for the Raspberry Pi Pico have been merged to probe-rs, and the fork
+is not needed anymore.
 
 ### Hardware Based Testing
 
@@ -109,7 +112,9 @@ To push this project a little further, we have put up a posting for a BSc thesis
 
 We announced the [hs-probe](https://github.com/probe-rs/hs-probe) quite a while ago. Many of you have ordered one already. Unfortunately the manufacturing was hit by the global chip shortages as well. The good news is that manufacturing has concluded today and the probes now go into programming. This means we can start the shipping of the probes soon!
 [Emil](https://github.com/korken89) has been working really hard to make this a possibility and get the probe manufactured even during chip shortages!
-If you have not ordered a probe yet, and would like to get ahold one, you can do so on our [shop](https://shop.probe.rs/).
+~~If you have not ordered a probe yet, and would like to get ahold one, you can do so on our shop~~.
+
+Note: The hs-probe is not available for sale anymore, as all produced units have been sold. We might produce an updated version in the future.
 
 ### Automatic Releases
 

--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -44,7 +44,7 @@ dnf install libusbx-devel libftdi-devel libudev-devel openssl-devel
 
 ## Windows
 
-On Windows you can use [vcpkg](https://github.com/microsoft/vcpkg#quick-start-windows) to install the prerequisites:
+On Windows you can use [vcpkg](https://github.com/microsoft/vcpkg/#quick-start-windows) to install the prerequisites:
 
 ```
 # dynamic linking 64-bit

--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ Additionally, probe-rs depends on [libusb](https://libusb.info/) and optionally 
 On Debian and derived distros (e.g. Ubuntu), the following packages need to be installed:
 
 ```bash
-sudo apt install -y pkg-config libusb-1.0-0-dev libftdi1-dev libudev-dev
+sudo apt install -y pkg-config libusb-1.0-0-dev libftdi1-dev libudev-dev libssl-dev
 ```
 
 If the libusb v0.1 dev package (`libusb-dev`) is installed when dependant crates are built, you may get link failures at the end of the build.
@@ -39,7 +39,7 @@ sudo apt purge libusb-dev
 ## RPM-based Linux (Fedora, CentOS)
 
 ```
-dnf install systemd-devel libusbx-devel
+dnf install libusbx-devel libftdi-devel libudev-devel openssl-devel
 ```
 
 ## Windows

--- a/content/docs/getting-started/probe-setup.md
+++ b/content/docs/getting-started/probe-setup.md
@@ -22,10 +22,10 @@ The [ST-Link](#st-link), to [J-Link](#segger-j-link) and [CMSIS-DAP](#cmsis-dap)
 # udev rules
 
 By default, the debug probes are only accessible by users with root privileges on Linux based systems.
-It is recommend to use appropriate udev rules to allow users without root privileges 
+It is recommend to use appropriate udev rules to allow users without root privileges
 access to the debug probes as well.
 
-1. Download the file [69-probe-rs.rules](/files/69-probe-rs.rules)[^1] and place it in /etc/udev/rules.d. 
+1. Download the file [69-probe-rs.rules](/files/69-probe-rs.rules)[^1] and place it in /etc/udev/rules.d.
 2. Run `udevadm control --reload` to ensure the new rules are used.
 3. Run  `udevadm trigger` to ensure the new rules are applied to already added devices.
 
@@ -42,7 +42,7 @@ standard are supported by probe-rs.
 
 ### Linux
 
-No additional drivers are required to use CMSIS-DAP based probes on Linux systems. 
+No additional drivers are required to use CMSIS-DAP based probes on Linux systems.
 To ensure that users without root privileges can use the debug probe, it is recommended to
 configure udev as described in [udev rules](#udev-rules).
 
@@ -56,7 +56,7 @@ No driver installation required.
 
 # ST-Link
 
-The ST-Link is a debug probe from ST Microelectronics. 
+The ST-Link is a debug probe from ST Microelectronics.
 It is commonly found on their evaluation boards,
 such as the Discovery and Nucleo boards.
 
@@ -64,14 +64,14 @@ such as the Discovery and Nucleo boards.
 
 ### Linux
 
-No additional drivers are required to use a ST-Link debug probe on Linux systems. 
+No additional drivers are required to use a ST-Link debug probe on Linux systems.
 To ensure that users without root privileges can use the debug probe, it is recommended to
 configure udev as described in [udev rules](#udev-rules).
 
 ### Windows
 
 To use the ST-Link on Windows, you need to install the official drivers, which can be found on
-the [ST website](https://www.st.com/content/st_com/en/products/development-tools/software-development-tools/stm32-software-development-tools/stm32-utilities/stsw-link009.html).
+the [ST website](https://www.st.com/en/development-tools/stsw-link009.html).
 
 
 ### Mac OS
@@ -88,7 +88,7 @@ The following versions of the ST-Link are supported:
 
 If you get an error message indicating that the firmware is outdated, please use the
 official ST tools to update the firmware.
-The update tool can be found on 
+The update tool can be found on
 the [ST website](https://www.st.com/en/development-tools/stsw-link007.html).
 
 # SEGGER J-Link
@@ -102,7 +102,7 @@ Due to the proprietary nature of the J-Link, probe-rs will not achieve the same 
 
 ### Linux
 
-No additional drivers are required to use a J-Link debug probe on Linux systems. 
+No additional drivers are required to use a J-Link debug probe on Linux systems.
 To ensure that users without root privileges can use the debug probe, it is recommended to
 configure udev as described in [udev rules](#udev-rules).
 
@@ -111,7 +111,7 @@ configure udev as described in [udev rules](#udev-rules).
 Unfortunately, probe-rs doesn't work with the official drivers on Windows. To use probe-rs
 it is necessary to install a generic WinUSB driver. The recommended way of doing this is
 by using [Zadig](https://zadig.akeo.ie/) and selecting WinUSB as the driver for the J-Link probe.
-This will uninstall the official driver, 
+This will uninstall the official driver,
 which means that the official Segger tools will not work anymore after this.
 
 

--- a/content/docs/library/quickstart.md
+++ b/content/docs/library/quickstart.md
@@ -115,6 +115,6 @@ Downloading firmware to your target is as easy.
 Of course the flash facility can also report progress.
 
 Any target that has a CMSIS-Pack can be converted into a **probe-rs** flash download target with our
-[utility](https://github.com/probe-rs/target-gen)
+[utility](https://github.com/probe-rs/probe-rs/tree/master/target-gen)
 
 Read more about [downloading flash](/guide/downloading).

--- a/content/docs/tools/cargo-embed.md
+++ b/content/docs/tools/cargo-embed.md
@@ -61,7 +61,7 @@ enabled = true
 ```
 
 All available options can be found in the
-[default.toml](https://github.com/probe-rs/probe-rs/blob/master/probe-rs/src/bin/probe-rs/cargo_embed/config/default.toml). This
+[default.toml](https://github.com/probe-rs/probe-rs/blob/master/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml). This
 example uses toml syntax to set each option under the `default` top-level profile key.
 
 The `Embed.toml` should be part of the project, i.e. added to Git history. For local-only configuration overrides, you can


### PR DESCRIPTION
Fix #79 and #83, and update some additional broken links which were found using `zola check`. It unfortunately has some false positives, otherwise it would be nice to run it automatically once a week or so.