### PR TITLE
docs: fix outdated cli call

### DIFF
--- a/content/docs/tools/cargo-flash.md
+++ b/content/docs/tools/cargo-flash.md
@@ -36,7 +36,7 @@ cargo flash --release --chip <chip_name>
 
 # Don't know if your target is supported
 # by cargo flash and what it's name is?
-probe-rs chip info
+probe-rs chip list
 
 # You can run your examples as usual with
 cargo flash --example <your_example>

--- a/content/docs/tools/cargo-flash.md
+++ b/content/docs/tools/cargo-flash.md
@@ -36,7 +36,7 @@ cargo flash --release --chip <chip_name>
 
 # Don't know if your target is supported
 # by cargo flash and what it's name is?
-cargo flash --list-chips
+probe-rs chip info
 
 # You can run your examples as usual with
 cargo flash --example <your_example>


### PR DESCRIPTION
The docs are outdated here, there is no more `--list-chips` - the equivalent seems to be `probe-rs info`.
This fixes: https://github.com/probe-rs/probe-rs/issues/1736