### PR TITLE
Update docs based on crate restructuring

### DIFF
--- a/src/docs/getting-started/installation.md
+++ b/src/docs/getting-started/installation.md
@@ -62,5 +62,5 @@ No additional setup is required.
 Install with `cargo install`. This will install the `probe-rs`, `cargo-flash` and `cargo-embed` binaries and put them in `$PATH`.
 
 ```bash
-cargo install probe-rs --features cli
+cargo install probe-rs-tools
 ```

--- a/src/docs/getting-started/installation.md
+++ b/src/docs/getting-started/installation.md
@@ -59,8 +59,10 @@ No additional setup is required.
 
 ### Installation
 
-Install with `cargo install`. This will install the `probe-rs`, `cargo-flash` and `cargo-embed` binaries and put them in `$PATH`.
+Install with `cargo install`. This will download the latest **development** sources, compile them, install the `probe-rs`, `cargo-flash` and `cargo-embed` binaries and put them in `$PATH`.
 
 ```bash
-cargo install probe-rs-tools
+cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --locked
 ```
+
+See the [Cargo book](https://doc.rust-lang.org/cargo/commands/cargo-install.html) for details.

--- a/src/docs/library/crosscompiling.md
+++ b/src/docs/library/crosscompiling.md
@@ -62,7 +62,7 @@ Add the following to the `Cross.toml`. Which will define to `cross` which contai
 docker build -t crossimage crossimage/
 
 # Run cross to compile, cross arguments are the same as the `cargo` ones
-cross build --release --target=armv7-unknown-linux-gnueabihf --features cli
+cross build --release --target=armv7-unknown-linux-gnueabihf
 
 # Done
 ```

--- a/src/docs/library/crosscompiling.md
+++ b/src/docs/library/crosscompiling.md
@@ -6,9 +6,9 @@ order: 100
 
 Even though **probe-rs** can run on most systems, there can be cases where using `cargo install` is not possible due to system permissions or resource limitations.
 
-In such cases you can Crosscompile **probe-rs** for use in **cargo-flash** or **cargo-embed** on a different architecture, and move the resulting static binary to the target system.
+In such cases you can cross-compile **probe-rs** for use in **cargo-flash** or **cargo-embed** on a different architecture, and move the resulting static binary to the target system.
 
-We will use a [**Raspberry pi 400**](https://www.raspberrypi.org/products/raspberry-pi-400/) as the target system as an example, where `cargo install probe-rs` on a default **Raspberry PI OS** installation is not possible to pass the `rustc` final Linking step for `probe-rs` due to system memory limitations.
+We will use a [**Raspberry pi 400**](https://www.raspberrypi.org/products/raspberry-pi-400/) as the target system as an example, where `cargo install` on a default **Raspberry PI OS** installation can not pass the `rustc` final Linking step due to system memory limitations.
 
 After defining the target system architecture, in this example being `armv7-unknown-linux-gnueabihf`, here are two different ways to Crosscompile, each with their pros and cons.
 
@@ -52,17 +52,17 @@ vim Cross.toml
 
 Add the following to the `Cross.toml`. Which will define to `cross` which container should be used for the target architecture:
 
-    ```toml
-    [target.armv7-unknown-linux-gnueabihf]
-    image = "crossimage"
-    ```
+```toml
+[target.armv7-unknown-linux-gnueabihf]
+image = "crossimage"
+```
 
 ```sh
 # Build and tag the container image, specifying the name as defined in the `Cross.toml`.
 docker build -t crossimage crossimage/
 
 # Run cross to compile, cross arguments are the same as the `cargo` ones
-cross build --release --target=armv7-unknown-linux-gnueabihf
+cross build --path probe-rs-tools --release --target=armv7-unknown-linux-gnueabihf
 
 # Done
 ```

--- a/src/docs/tools/cargo-embed.md
+++ b/src/docs/tools/cargo-embed.md
@@ -60,7 +60,7 @@ enabled = true
 ```
 
 All available options can be found in the
-[default.toml](https://github.com/probe-rs/probe-rs/blob/master/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml.toml).
+[default.toml](https://github.com/probe-rs/probe-rs/blob/master/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml).
 This example uses toml syntax to set each option under the `default` top-level
 profile key.
 

--- a/src/docs/tools/cargo-embed.md
+++ b/src/docs/tools/cargo-embed.md
@@ -60,7 +60,7 @@ enabled = true
 ```
 
 All available options can be found in the
-[default.toml](https://github.com/probe-rs/probe-rs/blob/master/probe-rs/src/bin/probe-rs/cmd/cargo_embed/config/default.toml).
+[default.toml](https://github.com/probe-rs/probe-rs/blob/master/probe-rs-tools/src/bin/probe-rs/cmd/cargo_embed/config/default.toml.toml).
 This example uses toml syntax to set each option under the `default` top-level
 profile key.
 

--- a/src/docs/tools/cargo-flash.md
+++ b/src/docs/tools/cargo-flash.md
@@ -20,7 +20,7 @@ Here are the basics
 
 ```sh
 # Installing cargo flash is simple:
-cargo install probe-rs --features cli
+cargo install probe-rs-tools
 
 # In your cargo project directory, call
 cargo flash --release --chip <chip_name>

--- a/src/docs/tools/cargo-flash.md
+++ b/src/docs/tools/cargo-flash.md
@@ -18,7 +18,7 @@ You can use **cargo-flash** just like 'cargo run', but instead of running on the
 
 Here are the basics
 
-**cargo-embed** is installed as part of the **probe-rs** group of tools, see the
+**cargo-flash** is installed as part of the **probe-rs** group of tools, see the
 [Installation](/docs/getting-started/installation) page.
 
 ```sh

--- a/src/docs/tools/cargo-flash.md
+++ b/src/docs/tools/cargo-flash.md
@@ -18,10 +18,10 @@ You can use **cargo-flash** just like 'cargo run', but instead of running on the
 
 Here are the basics
 
-```sh
-# Installing cargo flash is simple:
-cargo install probe-rs-tools
+**cargo-embed** is installed as part of the **probe-rs** group of tools, see the
+[Installation](/docs/getting-started/installation) page.
 
+```sh
 # In your cargo project directory, call
 cargo flash --release --chip <chip_name>
 


### PR DESCRIPTION
* Install target folder is now probe-rs-tools
* Fixed dead link to default cargo-embed toml
* Associated PR: https://github.com/probe-rs/probe-rs/pull/2431