### PR TITLE
How to install latest release from source

### DIFF
--- a/src/docs/getting-started/installation.md
+++ b/src/docs/getting-started/installation.md
@@ -59,10 +59,11 @@ No additional setup is required.
 
 ### Installation
 
-Install with `cargo install`. This will download the latest **development** sources, compile them, install the `probe-rs`, `cargo-flash` and `cargo-embed` binaries and put them in `$PATH`.
+`cargo install` will download, compile and install `probe-rs`, `cargo-flash` and `cargo-embed` for you.
 
-```bash
-cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --locked
-```
+You have multiple options, the two most interesting are:
+
+- To install the latest release, run `cargo install probe-rs-tools`
+- To try the latest development version (a.k.a the `master` branch) with experimental and unreleased changes, run `cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --locked`
 
 See the [Cargo book](https://doc.rust-lang.org/cargo/commands/cargo-install.html) for details.


### PR DESCRIPTION
We accidentally released to crates.io so we might as well have the instructions in place, too.