### PR TITLE
Update docs around DEFMT_LOG

### DIFF
--- a/src/docs/knowledge-base/troubleshooting.md
+++ b/src/docs/knowledge-base/troubleshooting.md
@@ -21,8 +21,7 @@ This can be set multiple ways:
     DEFMT_LOG = "trace"
     ```
 - If using [VSCode plugin](https://probe.rs/docs/tools/debugger/),
-  - It should be set in `.vscode/launch.json` under configurations/coreConfigs/options.
-  - Also be sure `rttEnabled` is `true` and `consoleLogLevel` is set to appropriate filter level:
+  - Make sure `rttEnabled` is `true` and `consoleLogLevel` is set to appropriate filter level:
     ```json
     {
         "version": "0.2.0",
@@ -30,12 +29,7 @@ This can be set multiple ways:
             // SNIP...
             "coreConfigs": [{
                 // SNIP ...,
-                "rttEnabled": true,
-                "options": {
-                    "env": {
-                        "DEFMT_LOG": "Trace" // Trace, Debug, Info, Warn, Error
-                    }
-                },
+                "rttEnabled": true
             }],
             "consoleLogLevel": "Console", //Console, Info, Debug
         }],

--- a/src/docs/tools/debugger.md
+++ b/src/docs/tools/debugger.md
@@ -291,11 +291,7 @@ configuration.
           "coreIndex": 0,
           "rttEnabled": true
         }
-      ],
-      "env": {
-        //!MODIFY: Remove or use any of the supported DEFMT_LOG options.
-        "DEFMT_LOG": "info"
-      }
+      ]
     }
   ]
 }
@@ -317,17 +313,17 @@ before entering low power.
 - The `defmt` crate introduced a new log filter that filters out log statements
   at **build time**. To ensure your defmt logging is not default filtered to
   `error` level, you can either add the environment variable in your
-  `.cargo/config` file, or add the `options` setting of your tasks.json (see
+  `.cargo/config` file, or add the `options` setting of your `tasks.json` (see
   below), to match your desired logging level on the target.
 
-Adding DEFMT_LOG to `cargo/config`
+Adding `DEFMT_LOG` to `.cargo/config.toml`
 
 ```toml
 [env]
 DEFMT_LOG = "info"
 ```
 
-Adding DEFMT_LOG to `tasks.json`
+Adding `DEFMT_LOG` to `tasks.json`
 
 ```json
 // ... <snip> ...


### PR DESCRIPTION
Setting an env var in `launch.json` has no effect.