### PR TITLE
Fix tcp-socket image too wide on cargo-embed docs

### DIFF
--- a/src/docs/tools/cargo-embed.md
+++ b/src/docs/tools/cargo-embed.md
@@ -334,7 +334,7 @@ tabs = [
 
 This screenshot shows how it can be used with a single socket. The logger is configured to redirect `log::trace!()` to channel 1, which is then sent to the real time plotting app.
 
-![Real time plotting rtt data via tcp](/images/cargo-embed-tcp-socket.png)
+<img src="/images/cargo-embed-tcp-socket.png" alt="Real time plotting rtt data via tcp" width="100%"/>
 
 Note that the raw bytes are send over the socket, so no timestamps are added, nor any parsing or line splitting is done. You have all the flexibility to do this yourself in the tcp endpoint.
 

--- a/src/docs/tools/cargo-embed.md
+++ b/src/docs/tools/cargo-embed.md
@@ -334,7 +334,7 @@ tabs = [
 
 This screenshot shows how it can be used with a single socket. The logger is configured to redirect `log::trace!()` to channel 1, which is then sent to the real time plotting app.
 
-<img src="/images/cargo-embed-tcp-socket.png" alt="Real time plotting rtt data via tcp" width="100%"/>
+![Real time plotting rtt data via tcp](/images/cargo-embed-tcp-socket.png){: width="100%" }
 
 Note that the raw bytes are send over the socket, so no timestamps are added, nor any parsing or line splitting is done. You have all the flexibility to do this yourself in the tcp endpoint.
 


### PR DESCRIPTION
On the cargo-embed website, the tcp-socket image is far too wide on my screen:

![image](https://github.com/user-attachments/assets/2d82d3e0-a7e7-4ee4-963f-8d489b387562)
