### PR TITLE
Re-add WCH Link probe

### DIFF
--- a/public/files/69-probe-rs.rules
+++ b/public/files/69-probe-rs.rules
@@ -141,6 +141,7 @@ ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1002", MODE="660", GROUP="plugdev", 
 # CMSIS-DAP compatible adapters
 ATTRS{product}=="*CMSIS-DAP*", MODE="660", GROUP="plugdev", TAG+="uaccess"
 # WCH Link (CMSIS-DAP compatible adapter)
+ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8010", MODE="660", GROUP="plugdev", TAG+="uaccess"
 ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8011", MODE="660", GROUP="plugdev", TAG+="uaccess"
 
 LABEL="probe_rs_rules_end"


### PR DESCRIPTION
This got removed in the website rework.