### PR TITLE
Add Infineon KitProg to udev rules

### DIFF
--- a/public/files/69-probe-rs.rules
+++ b/public/files/69-probe-rs.rules
@@ -145,4 +145,7 @@ ATTRS{product}=="*CMSIS-DAP*", MODE="660", GROUP="plugdev", TAG+="uaccess"
 ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8010", MODE="660", GROUP="plugdev", TAG+="uaccess"
 ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="8011", MODE="660", GROUP="plugdev", TAG+="uaccess"
 
+# Infineon KitProg
+ATTRS{idVendor}=="04b4", ATTRS{idProduct}=="f155", MODE="660", GROUP="plugdev", TAG+="uaccess"
+
 LABEL="probe_rs_rules_end"


### PR DESCRIPTION
Allows for the probe-rs specific udev rules to cover the onboard debug probe that comes with many Infineon developer kits/evaluation boards.