### PR TITLE
docs: add linuxgpiod probe + Arduino UNO Q knowledge-base entry

### DIFF
--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -70,6 +70,11 @@ You have multiple options, the two most interesting are:
 - To install the latest release, run `cargo install probe-rs-tools --locked`
 - To try the latest development version (a.k.a the `master` branch) with experimental and unreleased changes, run `cargo install probe-rs-tools --git https://github.com/probe-rs/probe-rs --locked`
 
+On Linux, the host-side probe drivers from the `probe-rs-linux` crate
+([`linuxgpiod`](/docs/getting-started/probe-setup/#linux-gpio-bit-bang-linuxgpiod)
+and [`linuxspidevswd`](/docs/getting-started/probe-setup/#linux-spi-bit-bang-linuxspidevswd))
+are pulled in automatically — no Cargo features required.
+
 See the [Cargo book](https://doc.rust-lang.org/cargo/commands/cargo-install.html) for details.
 
 

--- a/src/content/docs/getting-started/probe-setup.mdx
+++ b/src/content/docs/getting-started/probe-setup.mdx
@@ -244,3 +244,139 @@ receive wire to pin "A3":
 ```console
 $ glasgow multi probe-rs -V A=3.3 --swclk A0 --swdio A1 ++ uart --rx A2 --tx A3 --auto-baud
 ```
+
+## Linux GPIO bit-bang (`linuxgpiod`)
+
+Bit-bangs SWD over GPIO lines exposed by the Linux kernel's character-device
+interface (`/dev/gpiochipN`). Useful when the host running probe-rs is itself
+a Linux SBC whose GPIOs are routed to a target SoC's SWD pins (typically
+through level shifters), and you don't want a separate USB debug probe in
+the picture.
+
+**Linux only. SWD only.** Effective bit rate is bounded by `gpio-cdev` ioctl
+throughput — typically tens of kHz.
+
+This driver lives in the `probe-rs-linux` plugin crate, which `probe-rs-tools`
+pulls in automatically on Linux — no Cargo features required.
+
+### Setup
+
+Pin assignments are passed via the `--probe` selector with VID and PID both
+set to zero, and the SWD line offsets in the serial field:
+
+```console
+$ probe-rs run \
+    --probe '0:0:gpiochip1,swclk=26,swdio=25,srst=38' \
+    --chip <CHIP> firmware.elf
+```
+
+`<gpiochip>` accepts `gpiochipN`, `/dev/gpiochipN`, or just the numeric
+index `N`. `srst` is optional — without it, target reset is software-only.
+
+#### Permissions
+
+`/dev/gpiochipN` is owned by `root:gpio` on most distributions. Add your
+user to the `gpio` group (or run probe-rs with `sudo`):
+
+```console
+$ sudo usermod -aG gpio $USER
+```
+
+Auto-discovery (`probe-rs list` with no `--probe`) does not enumerate gpiod
+probes — pin assignments are board-specific and cannot be inferred. You
+must always supply an explicit selector.
+
+For a worked end-to-end example on a real board, see the
+[Arduino UNO Q knowledge-base entry](/docs/knowledge-base/arduino-uno-q/).
+
+## Linux SPI bit-bang (`linuxspidevswd`)
+
+Emulates SWD over a Linux `spidev` bus by tying the host's PICO (MOSI) and
+POCI (MISO) lines together through a series resistor (~1 kΩ) and using that
+node as `SWDIO`. SCLK drives `SWCLK`. Useful when the host is a Linux SBC
+whose SPI peripheral is wired to a target's SWD pins, and you want speeds
+well above what `linuxgpiod` can sustain — this driver has been tested up
+to 18 MHz.
+
+**Linux only. SWD only.** Like `linuxgpiod`, this driver is part of the
+`probe-rs-linux` plugin crate and is registered automatically on Linux
+builds.
+
+### Wiring
+
+```text
+   Host                     Target
++--------+     1K         +--------+
+|    PICO|---/\/\/\---+   |        |
+|        |            |   |        |
+|    POCI|------------+---|SWDIO   |
+|        |                |        |
+|     SCK|----------------|SWDCLK  |
++--------+                +--------+
+```
+
+The exact resistor value depends on SWD clock speed and host/target drive
+strength; 1 kΩ is a good starting point.
+
+#### Raspberry Pi pinout (SPI0)
+
+| GPIO    | Function  | Header pin |
+|---------|-----------|------------|
+| GPIO 10 | SPI0 MOSI | 19         |
+| GPIO 9  | SPI0 MISO | 21         |
+| GPIO 11 | SPI0 SCLK | 23         |
+
+Enable SPI with `raspi-config` and reboot; the bus will appear as
+`/dev/spidev0.0`.
+
+### Probe selection
+
+Select the spidev device directly with a synthetic selector whose serial
+field carries the spidev path:
+
+```console
+$ probe-rs info --probe '0:0:/dev/spidev0.0'
+```
+
+The VID:PID portion is ignored.
+
+### Auto-discovery and the `spidev_swd` udev rule
+
+For safety, `probe-rs list` does **not** enumerate every SPI bus on the
+system — it only exposes spidev devices that are reachable through an
+explicit `/dev/spidev_swd*` symlink. To opt a bus into auto-discovery,
+create a udev rule:
+
+```console
+$ sudo tee /etc/udev/rules.d/99-spidev-swd.rules <<EOF
+SUBSYSTEM=="spi", KERNEL=="spidev*", SYMLINK+="spidev_swd%n"
+EOF
+```
+
+Explicit `--probe '0:0:/dev/spidevX.Y'` selectors always work regardless of
+whether the symlink exists.
+
+### Cross-compiling for a Raspberry Pi host
+
+```bash
+# Pi 1 / Pi Zero
+cross build -p probe-rs-tools --target arm-unknown-linux-gnueabihf --release --features remote
+
+# Pi 3 / 4 / 5
+cross build -p probe-rs-tools --target aarch64-unknown-linux-gnu --release --features remote
+```
+
+Copy the resulting binary onto the Pi and run it directly:
+
+```console
+$ ./probe-rs info --protocol swd --probe '0:0:/dev/spidev0.0' --speed 1000
+```
+
+To drive the Pi remotely from a workstation, run `probe-rs serve` on the Pi
+(see the [`probe-rs` tool docs](/docs/tools/probe-rs/) for the server
+config) and point a remote client at it:
+
+```console
+$ probe-rs --host ws://pi-zero-w.local:3000 --token "token" \
+    info --protocol swd --speed 1000 --probe '0:0:/dev/spidev0.0'
+```

--- a/src/content/docs/knowledge-base/arduino-uno-q.mdx
+++ b/src/content/docs/knowledge-base/arduino-uno-q.mdx
@@ -1,0 +1,75 @@
+---
+title: "Arduino UNO Q (STM32U585)"
+description: "Debug the on-board STM32U585 from the QRB2210 Linux host using probe-rs's linuxgpiod driver."
+order: 35
+---
+
+## Overview
+
+The [Arduino UNO Q](https://docs.arduino.cc/hardware/uno-q/) pairs a
+Qualcomm QRB2210 (Snapdragon 215 running Linux) with an STM32U585OI
+(Cortex-M33). The QRB2210's GPIOs reach the STM32's SWD pins through
+on-board level shifters, which the
+[`linuxgpiod`](/docs/getting-started/probe-setup/#linux-gpio-bit-bang-linuxgpiod)
+driver can drive directly.
+
+## Pin map
+
+| Signal | gpiochip   | Line |
+|--------|------------|------|
+| SWCLK  | `gpiochip1` | 26   |
+| SWDIO  | `gpiochip1` | 25   |
+| SRST   | `gpiochip1` | 38   |
+
+Selector for all probe-rs commands:
+
+```text
+0:0:gpiochip1,swclk=26,swdio=25,srst=38
+```
+
+## Chip description (one-time)
+
+probe-rs doesn't currently bundle the STM32U5 family. Generate a YAML
+description from STMicroelectronics' CMSIS pack with `target-gen`:
+
+```console
+$ curl -sSL -o pack.pack \
+    https://www.keil.com/pack/Keil.STM32U5xx_DFP.3.2.0.pack
+$ target-gen pack pack.pack ./u5-targets/
+```
+
+Pass the resulting `STM32U5_Series.yaml` via `--chip-description-path`;
+use the full STM package code as the chip name (`STM32U585OIYxQ` for the
+UNO Q):
+
+```console
+$ probe-rs info \
+    --probe '0:0:gpiochip1,swclk=26,swdio=25,srst=38' \
+    --chip STM32U585OIYxQ \
+    --chip-description-path ./u5-targets/STM32U5_Series.yaml
+```
+
+## Auto-boot quirk
+
+Stock UNO Q boards ship with the STM32U585's `NSBOOTADD1R` option byte set
+to `0x0BF90000`, so reset lands in the chip's ROM bootloader rather than
+user flash. probe-rs flashes user firmware correctly, but the chip won't
+auto-boot it on reset until `NSBOOTADD1R` is repointed at `0x08000000`.
+This is a one-time per-board option-byte change; use any STM32 option-byte
+programming tool.
+
+## Flashing and running firmware
+
+```console
+$ sudo probe-rs run \
+    --probe '0:0:gpiochip1,swclk=26,swdio=25,srst=38' \
+    --chip STM32U585OIYxQ \
+    --chip-description-path ./u5-targets/STM32U5_Series.yaml \
+    firmware.elf
+     Erasing ✔ [00:00:01] [#####] 16.00 KiB / 16.00 KiB
+ Programming ✔ [00:00:02] [#####] 11.51 KiB / 11.51 KiB
+    Finished in 4.7s
+[INFO ] firmware booted
+```
+
+probe-rs streams `defmt` log output over RTT until `^C`.


### PR DESCRIPTION
Companion docs for probe-rs#3986.

- probe-setup: new "Linux GPIO bit-bang (linuxgpiod)" section after Glasgow, covering selector format, gpio-cdev permissions, and the opt-in feature flag.
- installation: one-line note pointing at the linuxgpiod feature when installing from source.
- knowledge-base: new "Arduino UNO Q (STM32U585)" page with a complete recipe (pin map, CMSIS-pack chip description, one-time NSBOOTADD1R option-byte gotcha, single-command flash + RTT session).