### PR TITLE
Document how to uninstall probe-rs

### DIFF
--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -73,6 +73,44 @@ You have multiple options, the two most interesting are:
 See the [Cargo book](https://doc.rust-lang.org/cargo/commands/cargo-install.html) for details.
 
 
+## Uninstalling
+
+How you remove probe-rs depends on how you installed it.
+
+### Install scripts
+
+The install scripts don't ship an uninstaller, so the binaries have to be
+removed by hand. They are placed in Cargo's binary directory
+(`~/.cargo/bin`, or `%USERPROFILE%\.cargo\bin` on Windows):
+
+```bash
+rm ~/.cargo/bin/probe-rs ~/.cargo/bin/cargo-flash ~/.cargo/bin/cargo-embed
+```
+
+The installer also drops an install receipt that you can remove:
+
+```bash
+rm -r ~/.config/probe-rs-tools
+```
+
+If you installed shell completions with `probe-rs complete install`, delete the
+completion file it created for your shell. If you allowed the installer to
+modify your `PATH`, remove the line it added to your shell profile.
+
+### homebrew
+
+```bash
+brew uninstall probe-rs
+brew untap probe-rs/probe-rs
+```
+
+### cargo (`cargo install` / `cargo binstall`)
+
+```bash
+cargo uninstall probe-rs-tools
+```
+
+
 ## Shell completion
 
 You likely want to install shell completion support along with the probe-rs binaries. Just run:


### PR DESCRIPTION
The install scripts are generated by dist and don't ship an uninstaller, so users had to reverse-engineer which files to delete (see probe-rs/probe-rs#3239). This adds an "Uninstalling" section to the installation page:

- **Install scripts**: remove the `probe-rs`/`cargo-flash`/`cargo-embed` binaries from `~/.cargo/bin`, plus the install receipt under `~/.config/probe-rs-tools`, with notes about shell completions and PATH.
- **homebrew**: `brew uninstall` + `brew untap`.
- **cargo**: `cargo uninstall probe-rs-tools`.

Closes probe-rs/probe-rs#3239.