### PR TITLE
docs: add known limitations for Infineon devices

### DIFF
--- a/src/content/docs/knowledge-base/infineon-known-limitations.mdx
+++ b/src/content/docs/knowledge-base/infineon-known-limitations.mdx
@@ -1,0 +1,13 @@
+---
+title: "Infineon Devices: Known Limitations"
+description: "Known limitations when using probe-rs with Infineon devices."
+order: 60
+---
+
+- Programming of Bank 2 in dual-bank flash is not supported on dual-bank PSOC C3 and PSOC C3 x7/x8 devices.
+- Memory maps for PSoC Edge E84 do not reflect configurations utilizing reclaimed RRAM.
+- The `read` and `write` commands do not enforce validation of target address ranges, permitting access to addresses outside defined memory regions. This limitation applies to all targets.
+- The PSOC Edge E84 exclusively supports the default external 16Mb QSPI flash; alternative or secondary QSPI memory configurations are not supported at this time.
+- Custom external memory on the KIT_PSE84_HMI device is not supported. Please refrain from using full device erase operations, including the `erase` command or the `--chip-erase` subcommand, as these actions may result in unintended consequences.
+- JTAG-based debugging is not available on PSOC Edge E84 and PSOC C3 devices; only SWD is supported.
+- J-Link OB (on-board) probes do not support SWD speeds above 3000 kHz; use `--speed 3000` or lower.


### PR DESCRIPTION
Adds a new knowledge-base page (src/content/docs/knowledge-base/infineon-known-limitations.mdx) listing current known limitations for Infineon devices (PSoC C3, PSoC Edge E84, KIT_PSE84_HMI) and J-Link OB probes.